### PR TITLE
Create subdirectories if specified in password path

### DIFF
--- a/pypass/passwordstore.py
+++ b/pypass/passwordstore.py
@@ -148,6 +148,9 @@ class PasswordStore(object):
             os.path.join(self.path, path + '.gpg')
         )
 
+        if not os.path.isdir(os.path.dirname(passfile_path)):
+            os.makedirs(os.path.dirname(passfile_path))
+
         gpg = subprocess.Popen(
             [
                 GPG_BIN,

--- a/pypass/tests/test_passwordstore.py
+++ b/pypass/tests/test_passwordstore.py
@@ -121,16 +121,21 @@ class TestPasswordStore(unittest.TestCase):
 
     def test_get_decrypted_password_deeply_nested(self):
         store = PasswordStore(self.dir)
-        password = 'Alice'
-        store.insert_password('A/B/C/D/hello.com', password)
-        store.insert_password('A/B/C/hello.com', password)
+        self.assertFalse(
+            os.path.isdir(os.path.join(self.dir, 'A', 'B', 'C'))
+        )
+        store.insert_password('A/B/C/D/hello.com', 'Alice')
+        store.insert_password('A/B/C/hello.com', 'Bob')
         self.assertEqual(
             'Alice',
             store.get_decrypted_password('A/B/C/D/hello.com')
         )
         self.assertEqual(
-            'Alice',
+            'Bob',
             store.get_decrypted_password('A/B/C/hello.com')
+        )
+        self.assertTrue(
+            os.path.isdir(os.path.join(self.dir, 'A', 'B', 'C', 'D'))
         )
 
     def test_init(self):

--- a/pypass/tests/test_passwordstore.py
+++ b/pypass/tests/test_passwordstore.py
@@ -114,6 +114,24 @@ class TestPasswordStore(unittest.TestCase):
         store = PasswordStore(self.dir)
         password = 'ELLO'
         store.insert_password('hello.com', password)
+        self.assertEqual(
+            'ELLO',
+            store.get_decrypted_password('hello.com')
+        )
+
+    def test_get_decrypted_password_deeply_nested(self):
+        store = PasswordStore(self.dir)
+        password = 'Alice'
+        store.insert_password('A/B/C/D/hello.com', password)
+        store.insert_password('A/B/C/hello.com', password)
+        self.assertEqual(
+            'Alice',
+            store.get_decrypted_password('A/B/C/D/hello.com')
+        )
+        self.assertEqual(
+            'Alice',
+            store.get_decrypted_password('A/B/C/hello.com')
+        )
 
     def test_init(self):
         init_dir = tempfile.mkdtemp()


### PR DESCRIPTION
This patch allows to specify password entries in subdirectories.
If the directory does not exist, it will be created before invoking gnupg.