### PR TITLE
Use dulwich instead of git internally

### DIFF
--- a/pypass/command.py
+++ b/pypass/command.py
@@ -36,16 +36,12 @@ from pypass import PasswordStore
               envvar='PASSWORD_STORE_DIR',
               default=os.path.join(os.getenv("HOME"), ".password-store"),
               type=click.Path(file_okay=False, resolve_path=True))
-@click.option('--PASSWORD_STORE_GIT',
-              envvar='PASSWORD_STORE_GIT',
-              type=click.Path(file_okay=False, resolve_path=True),
-              default=None)
 @click.option('--EDITOR',
               envvar='EDITOR',
               default='editor',
               type=click.STRING)
 @click.pass_context
-def main(ctx, password_store_dir, password_store_git, editor):
+def main(ctx, password_store_dir, editor):
 
     # init does not need any of this.
     if ctx.invoked_subcommand == "init":
@@ -54,8 +50,7 @@ def main(ctx, password_store_dir, password_store_git, editor):
     # Prepare the config file
     config = {
         'password_store': PasswordStore(
-            path=password_store_dir,
-            git_dir=password_store_git
+            path=password_store_dir
         ),
         'editor': editor
     }
@@ -438,7 +433,8 @@ def git(config, commands):
         subprocess.call(
             [
                 'git',
-                '--git-dir=%s' % config['password_store'].git_dir,
+                '--git-dir=%s' % os.path.join(
+                    config['password_store'].path, '.git'),
                 '--work-tree=%s' % config['password_store'].path,
             ] + command_list,
             shell=False,

--- a/pypass/command.py
+++ b/pypass/command.py
@@ -119,7 +119,7 @@ def insert(config, path, echo, multiline):
 
     if config['password_store'].uses_git:
         config['password_store'].git_add_and_commit(
-            path + '.gpg',
+            [path + '.gpg'],
             message='Add given password for %s to store.' % path
         )
 
@@ -150,7 +150,7 @@ def generate(config, pass_name, pass_length, no_symbols, clip, in_place):
 
     if config['password_store'].uses_git:
         config['password_store'].git_add_and_commit(
-            pass_name + '.gpg',
+            [pass_name + '.gpg'],
             message='%s generated password for %s.' % (
                 'Replace' if in_place else 'Add',
                 pass_name
@@ -190,7 +190,7 @@ def edit(config, path):
 
             if config['password_store'].uses_git:
                 config['password_store'].git_add_and_commit(
-                    path + '.gpg',
+                    [path + '.gpg'],
                     message='Edited password for %s using %s'
                             % (path, config['editor'])
                 )

--- a/pypass/git_backend.py
+++ b/pypass/git_backend.py
@@ -1,0 +1,150 @@
+#
+#    Copyright (C) 2014 Alexandre Viau <alexandre@alexandreviau.net>
+#
+#    This file is part of python-pass.
+#
+#    python-pass is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    python-pass is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with python-pass.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from abc import ABCMeta, abstractmethod
+
+
+class GitBackend:
+    __metaclass__ = ABCMeta
+    """Generic Git backend, does nothing."""
+
+    @abstractmethod
+    def add(self, repo_path, files):
+        pass
+
+    @abstractmethod
+    def clone(self, url, target):
+        pass
+
+    @abstractmethod
+    def commit(self, repo_path, message=None):
+        pass
+
+    @abstractmethod
+    def init(self, repo_path):
+        pass
+
+
+class DulwichGitBackend(GitBackend):
+    def __init__(self):
+        from os import path
+        from dulwich import porcelain
+        self.path = path
+        self.porcelain = porcelain
+
+    def add(self, repo_path, files):
+        self.porcelain.add(
+            repo_path,
+            [self.path.join(repo_path, file_name) for file_name in files]
+        )
+
+    def clone(self, url, target):
+        self.porcelain.clone(url, target=target)
+
+    def commit(self, repo_path, message=None):
+        self.porcelain.commit(repo_path, message=message)
+
+    def init(self, repo_path):
+        self.porcelain.init(repo_path)
+
+
+class SubprocessGitBackend(GitBackend):
+    def __init__(self):
+        from os import path
+        from subprocess import call, Popen
+        self.path = path
+        self.call = call
+        self.Popen = Popen
+
+        self.call(
+            [
+                'git',
+                '--version'
+            ]
+        )
+
+    def add(self, repo_path, files):
+        self.Popen(
+            [
+                'git',
+                '--git-dir=%s'.format(self.path.join(repo_path, '.git')),
+                '--work-tree=%s'.format(repo_path),
+                'add'
+            ] + files,
+        ).wait()
+
+    def clone(self, url, target):
+        self.init(target)
+        self.Popen(
+            [
+                'git',
+                '--git-dir=%s'.format(self.path.join(target, '.git')),
+                '--work-tree=%s'.format(target),
+                'remote',
+                'add',
+                'origin',
+                url
+            ],
+            shell=False,
+        )
+        self.Popen(
+            [
+                'git',
+                '--git-dir=%s'.format(self.path.join(target, '.git')),
+                '--work-tree=%s'.format(target),
+                'pull',
+                'origin',
+                'master'
+            ],
+            shell=False,
+        )
+
+    def commit(self, repo_path, message=None):
+        if message:
+            self.call(
+                [
+                    'git',
+                    '--git-dir=%s'.format(self.ath.join(repo_path, '.git')),
+                    '--work-tree=%s'.format(repo_path),
+                    'commit',
+                    '-m',
+                    message
+                ]
+            )
+        else:
+            self.call(
+                [
+                    'git',
+                    '--git-dir=%s'.format(self.path.join(repo_path, '.git')),
+                    '--work-tree=%s'.format(repo_path),
+                    'commit'
+                ]
+            )
+
+    def init(self, repo_path):
+        self.Popen(
+            [
+                'git',
+                '--git-dir=%s'.format(self.path.join(repo_path, '.git')),
+                '--work-tree=%s'.format(repo_path),
+                'init',
+                repo_path
+            ],
+            shell=False,
+        ).wait()

--- a/pypass/passwordstore.py
+++ b/pypass/passwordstore.py
@@ -279,5 +279,8 @@ class PasswordStore(object):
         )
 
     def git_add_and_commit(self, files, message=None):
-        porcelain.add(self.path, [os.path.join(self.path, file_name) for file_name in files])
+        porcelain.add(
+            self.path,
+            [os.path.join(self.path, file_name) for file_name in files]
+        )
         porcelain.commit(self.path, message=message)

--- a/pypass/tests/test_command.py
+++ b/pypass/tests/test_command.py
@@ -427,7 +427,10 @@ class TestCommand(unittest.TestCase):
 
         open(os.path.join(origin_dir, 'test_git_init_clone.gpg'), 'a').close()
 
-        porcelain.add(origin_dir, [os.path.join(origin_dir, 'test_git_init_clone.gpg')])
+        porcelain.add(
+            origin_dir,
+            [os.path.join(origin_dir, 'test_git_init_clone.gpg')]
+        )
         porcelain.commit(origin_dir, message="testcommit")
 
         # Init

--- a/pypass/tests/test_command.py
+++ b/pypass/tests/test_command.py
@@ -26,6 +26,8 @@ import unittest
 
 import click.testing
 
+from dulwich import porcelain
+
 import pypass.command
 import pypass.tests
 from pypass.passwordstore import PasswordStore
@@ -420,39 +422,13 @@ class TestCommand(unittest.TestCase):
     def test_init_clone(self):
         # Setup origin repo
         origin_dir = tempfile.mkdtemp()
-        origin_git_dir = os.path.join(origin_dir, '.git')
 
-        subprocess.Popen(
-            [
-                'git',
-                '--git-dir=%s' % origin_git_dir,
-                '--work-tree=%s' % origin_dir,
-                'init',
-                origin_dir
-            ],
-            shell=False
-        ).wait()
+        porcelain.init(origin_dir)
 
         open(os.path.join(origin_dir, 'test_git_init_clone.gpg'), 'a').close()
 
-        subprocess.call(
-            [
-                'git',
-                '--git-dir=%s' % origin_git_dir,
-                '--work-tree=%s' % origin_dir,
-                'add', 'test_git_init_clone.gpg',
-            ]
-        )
-
-        subprocess.call(
-            [
-                'git',
-                '--git-dir=%s' % origin_git_dir,
-                '--work-tree=%s' % origin_dir,
-                'commit',
-                '-m', '"testcommit"',
-            ]
-        )
+        porcelain.add(origin_dir, [os.path.join(origin_dir, 'test_git_init_clone.gpg')])
+        porcelain.commit(origin_dir, message="testcommit")
 
         # Init
         self.run_cli(

--- a/pypass/tests/test_passwordstore.py
+++ b/pypass/tests/test_passwordstore.py
@@ -24,6 +24,8 @@ import subprocess
 import string
 import tempfile
 
+from dulwich import porcelain
+
 from pypass import PasswordStore
 from pypass import EntryType
 
@@ -186,37 +188,12 @@ class TestPasswordStore(unittest.TestCase):
         origin_dir = tempfile.mkdtemp()
         destination_dir = tempfile.mkdtemp()
 
-        subprocess.Popen(
-            [
-                'git',
-                '--git-dir=%s' % os.path.join(origin_dir, '.git'),
-                '--work-tree=%s' % origin_dir,
-                'init',
-                origin_dir
-            ],
-            shell=False
-        ).wait()
+        porcelain.init(origin_dir)
 
         open(os.path.join(origin_dir, 'test_git_init_clone.gpg'), 'a').close()
 
-        subprocess.Popen(
-            [
-                'git',
-                '--git-dir=%s' % os.path.join(origin_dir, '.git'),
-                '--work-tree=%s' % origin_dir,
-                'add', 'test_git_init_clone.gpg',
-            ]
-        ).wait()
-
-        subprocess.Popen(
-            [
-                'git',
-                '--git-dir=%s' % os.path.join(origin_dir, '.git'),
-                '--work-tree=%s' % origin_dir,
-                'commit',
-                '-m', '"testcommit"',
-            ]
-        ).wait()
+        porcelain.add(origin_dir, [os.path.join(origin_dir, 'test_git_init_clone.gpg')])
+        porcelain.commit(origin_dir, message="testcommit")
 
         # Init
         PasswordStore.init(

--- a/pypass/tests/test_passwordstore.py
+++ b/pypass/tests/test_passwordstore.py
@@ -20,7 +20,6 @@
 import unittest
 import os
 import shutil
-import subprocess
 import string
 import tempfile
 
@@ -192,7 +191,10 @@ class TestPasswordStore(unittest.TestCase):
 
         open(os.path.join(origin_dir, 'test_git_init_clone.gpg'), 'a').close()
 
-        porcelain.add(origin_dir, [os.path.join(origin_dir, 'test_git_init_clone.gpg')])
+        porcelain.add(
+            origin_dir,
+            [os.path.join(origin_dir, 'test_git_init_clone.gpg')]
+        )
         porcelain.commit(origin_dir, message="testcommit")
 
         # Init

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,4 @@ click
 colorama
 enum34
 pexpect
+dulwich


### PR DESCRIPTION
Because dulwich is a pure Python implementation of git, this means python-pass won't require the git client to exist, making it more portable to other systems.