### PR TITLE
Fix simple typo: pyppass -> pypass

### DIFF
--- a/docs/source/manpage.rst
+++ b/docs/source/manpage.rst
@@ -9,7 +9,7 @@ pypass [COMMAND] [OPTIONS] [ARGS]
 Description
 -----------
 
-pypass is a Python implementation of pass, a very simple password store that keeps passwords inside gpg2(1) encrypted files inside a simple directory tree residing at ~/.password-store. The pyppass utility provides a series of commands for manipulating the password store, allowing the user to add, remove, edit, synchronize, generate, and manipulate passwords.
+pypass is a Python implementation of pass, a very simple password store that keeps passwords inside gpg2(1) encrypted files inside a simple directory tree residing at ~/.password-store. The pypass utility provides a series of commands for manipulating the password store, allowing the user to add, remove, edit, synchronize, generate, and manipulate passwords.
 
 If no COMMAND is specified, COMMAND defaults to either show or ls, depending on the type of specifier in ARGS. Otherwise COMMAND must be one of the valid commands listed below.
 


### PR DESCRIPTION
Closes #27 